### PR TITLE
Make "art" peer-reviewed

### DIFF
--- a/inspire_hal/templates/hal/art.xml
+++ b/inspire_hal/templates/hal/art.xml
@@ -3,7 +3,7 @@
 {% block notesStmt %}
 <notesStmt>
   <note type="audience" n="2"/>
-  <note type="peer" n="{{ peer_reviewed }}"/>
+  <note type="peer" n="1"/>
   <note type="popular" n="{{ divulgation }}"/>
 </notesStmt>
 {% endblock notesStmt %}


### PR DESCRIPTION
* Previously, we used the `refereed` flag in the record to decide
  whether articles were peer-reviewed. Now all `art` records
  (non-conference articles published in journals) are flagged as
  peer-reviewed.

* INSPIR-2848

Signed-off-by: Micha Moskovic <michamos@gmail.com>