### PR TITLE
WIP Allow not updating the affiliations

### DIFF
--- a/inspire_hal/config.py
+++ b/inspire_hal/config.py
@@ -103,3 +103,7 @@ HAL_IGNORE_CERTIFICATES = False
 
 HAL_CONNECTION_TIMEOUT = 30
 """Timeout for HAL connection"""
+
+
+HAL_DISABLE_AFFILIATION_UPDATE = False
+"""Whether to disable updating affiliations when updating records."""


### PR DESCRIPTION
Tests are failing because the dependencies are not pinned. I tried updating them but that required using Python 3, and the SWORD2 library we use (our fork in https://github.com/inspirehep/python-client-sword2) is not compatible with Python 3 (it's using relative imports, but there might be more issues), so I leave this as a WIP, TBD in a future sprint.